### PR TITLE
Amp plugin support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "require": {
         "automattic/vipwpcs": "^2.0",
-        "wpackagist-plugin/wordpress-seo": "14.1"
+        "wpackagist-plugin/wordpress-seo": "14.1",
+        "wpackagist-plugin/amp":"1.5.3"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0982940468a2d38f9c4213a7f2e2bb1",
+    "content-hash": "9fd98c22975dd50345ca498d011e078a",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -275,6 +275,24 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "wpackagist-plugin/amp",
+            "version": "1.5.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/amp/",
+                "reference": "tags/1.5.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/amp.1.5.3.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/amp/"
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",

--- a/inc/plugin-patcher.php
+++ b/inc/plugin-patcher.php
@@ -21,6 +21,7 @@ if ($disableauthorsYoast) {
 $disableauthorsAmp = get_option('disableauthors_amp', 'on');
 if ($disableauthorsAmp) {
   add_filter('amp_post_template_data', 'disableauthorsAmpTemplateData');
+  add_filter('amp_post_template_metadata', 'disableauthorsAmpMetadata');
 
   function disableauthorsAmpTemplateData($template_data) {
     global $disableauthorsAuthorName;
@@ -33,5 +34,15 @@ if ($disableauthorsAmp) {
     }
 
     return $template_data;
+  }
+
+  function disableauthorsAmpMetadata($metadata) {
+    global $disableauthorsAuthorName;
+
+    if (isset($metadata['author'])) {
+      $metadata['author']['name'] = $disableauthorsAuthorName;
+    }
+
+    return $metadata;
   }
 }

--- a/inc/plugin-patcher.php
+++ b/inc/plugin-patcher.php
@@ -1,5 +1,7 @@
 <?php
 
+$disableauthorsAuthorName = get_option('disableauthors_default_name', 'Anonymous');
+
  // Yoast (wordpress-seo)
 $disableauthorsYoast = get_option('disableauthors_yoast', 'on');
 if ($disableauthorsYoast) {
@@ -11,5 +13,25 @@ if ($disableauthorsYoast) {
   function disableauthorsYoastSchema($schema) {
     $schema['author'] = get_bloginfo('name');
     return $schema;
+  }
+}
+
+// AMP
+// The amp plugin directly grabs user data and avoids all of the built in user filters
+$disableauthorsAmp = get_option('disableauthors_amp', 'on');
+if ($disableauthorsAmp) {
+  add_filter('amp_post_template_data', 'disableauthorsAmpTemplateData');
+
+  function disableauthorsAmpTemplateData($template_data) {
+    global $disableauthorsAuthorName;
+
+    if (isset($template_data['post_author'])) {
+      $template_data['post_author']->user_login = sanitize_user($disableauthorsAuthorName);
+      $template_data['post_author']->user_nicename = sanitize_user($disableauthorsAuthorName);
+      $template_data['post_author']->display_name = $disableauthorsAuthorName;
+      $template_data['post_author']->user_email = '';
+    }
+
+    return $template_data;
   }
 }

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -12,6 +12,7 @@ function disableauthors_settings_init(  ) {
 	register_setting('disableauthors', 'disableauthors_disable_feed', array( 'default' => true ));
 	register_setting('disableauthors', 'disableauthors_disable_author_pages', array( 'default' => true ));
 	register_setting('disableauthors', 'disableauthors_yoast', array( 'default' => true ));
+	register_setting('disableauthors', 'disableauthors_amp', array( 'default' => true ));
 
 	add_settings_section(
 		'disableauthors_pluginPage_settings_section',
@@ -45,6 +46,13 @@ function disableauthors_settings_init(  ) {
 		'disable-author-yoast',
 		__('Patch Yoast (wordpress-seo)', 'disableauthors'),
 		'disableauthors_field_yoast',
+		'disableauthors',
+		'disableauthors_pluginPage_settings_section'
+	);
+	add_settings_field(
+		'disable-author-amp',
+		__('Patch Amp', 'disableauthors'),
+		'disableauthors_field_amp',
 		'disableauthors',
 		'disableauthors_pluginPage_settings_section'
 	);
@@ -82,6 +90,15 @@ function disableauthors_field_yoast() {
 	?>
 	<label><input type="checkbox" name='disableauthors_yoast' <?php checked($checked); ?> /> <?php esc_html_e('Patch Yoast (wordpress-seo) plugin?', 'disableauthors'); ?></label>
 	<p><?php esc_html_e('Customizes Yoast to not output author details. Primarily affects ld+json output and may have an impact on seo.', 'disableauthors'); ?></p>
+	<?php
+}
+
+function disableauthors_field_amp() {
+	$option = get_option('disableauthors_amp', 'on');
+  $checked = $option === 'on';
+	?>
+	<label><input type="checkbox" name='disableauthors_amp' <?php checked($checked); ?> /> <?php esc_html_e('Patch AMP plugin?', 'disableauthors'); ?></label>
+	<p><?php esc_html_e('Filters the template data for AMP', 'disableauthors'); ?></p>
 	<?php
 }
 


### PR DESCRIPTION
Adds an option (default: enabled) to filter out the author name from the AMP plugin.