### PR TITLE
fix issue when non admins editors can't edit pages

### DIFF
--- a/inc/disable-author.php
+++ b/inc/disable-author.php
@@ -38,7 +38,7 @@ function disableauthors_disable_rest($response, $server, $request) {
       $method = $request->get_method();
       $route = $request->get_route();
       $is_user_listing = ($server::READABLE === $method && '/wp/v2/users' === substr($route, 0, 12));
-      if (!current_user_can('list_users') && $is_user_listing) {
+      if (!is_admin() && !current_user_can('list_users') && $is_user_listing) {
         exit;
       }
   }


### PR DESCRIPTION
When a user is trying to edit but don't have an admin role, the author rest request would fail.

https://app.clickup.com/t/868dmwq3x